### PR TITLE
remove `strpos` warning when prefix is empty

### DIFF
--- a/code/imsfdb.php
+++ b/code/imsfdb.php
@@ -63,7 +63,7 @@ class ImfsDb {
           if ( isset( $wpTables[ $name ] ) ) {
             $activeTable = true;
           }
-          if ( 0 === strpos( $name, $wpdb->prefix ) ) {
+          if ( !empty( $wpdb->prefix ) && 0 === strpos( $name, $wpdb->prefix ) ) {
             $activeTable = true;
           }
           if ( $activeTable ) {


### PR DESCRIPTION
This fixes a warning if you try to run the plugin with a WordPress installation without a prefix

```
PHP Warning:  strpos(): Empty needle in /plugins/index-wp-mysql-for-speed/code/imsfdb.php on line 66
```