### PR TITLE
Allow installation as a must-use plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *~
 **/hidden-test-treeshake/
 
+
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "olliejones/index-wp-mysql-for-speed",
+    "description": "A plugin to modernize indexes to your WordPress installation's MySQL database.",
+    "type": "wordpress-muplugin",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Oliver Jones"
+        },
+        {
+            "name": "Rick James"
+        }
+    ],
+    "require": {}
+}


### PR DESCRIPTION
Checks if the plugin is installed in the mu-plugins directory and directly requires the mu-plugin file. Otherwise the mu-plugin file is copied to the mu-plugins directory.

This allows for those who manage plugins as composer dependencies to install the plugin as an mu-plugin (see https://docs.roots.io/bedrock/master/mu-plugin-autoloader/).

Also included is a composer.json file for submitting this to packagist.org.

See issue #47 