### PR TITLE
build: add GitHub Actions workflow for build and archive

### DIFF
--- a/.github/workflows/build-archive.yml
+++ b/.github/workflows/build-archive.yml
@@ -1,0 +1,21 @@
+name: Build and Archive
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: index-wp-mysql-for-speed
+          path: .
+          compression-level: 9

--- a/.github/workflows/build-archive.yml
+++ b/.github/workflows/build-archive.yml
@@ -17,5 +17,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: index-wp-mysql-for-speed
-          path: .
+          path: |
+            ./
+            !composer.json
+            !composer.lock
+            !README.md
+            !CODE-OF-CONDUCT.md
+            !tests/**
           compression-level: 9


### PR DESCRIPTION
Hello,

I have set up a workflow to automatically compress the repository when a commit is made. 
This workflow only runs on the main branch.

The purpose is to facilitate access to an archive of the plugin for a specific commit.

Note: actions/upload-artifact does not include hidden files (.) or GitHub-related folders by default.

The only potential improvement for efficiency would be to include certain paths to ensure the workflow doesn't run if no modifications were made to the plugin code.

That said, it's an open-source project, and it's GitHub's servers doing the heavy lifting for free. :)
The workflow was tested on my repository & WordPress, and everything worked as expected.

TL;DR: Added a GitHub Actions workflow to archive the repository on commits to the main branch, matching the archive available on WordPress.org.