### PR TITLE
feat(ci): add daily Dependabot updates for GitHub Actions and Composer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR introduces Dependabot configuration for daily updates to both GitHub Actions and Composer dependencies. 

For more details, refer to the official [documentation](https://docs.github.com/github/managing-security-vulnerabilities/configuring-dependabot-security-updates).
